### PR TITLE
Increase CoAP buffer size

### DIFF
--- a/sys/net/application_layer/ota_suit/ota_suit.c
+++ b/sys/net/application_layer/ota_suit/ota_suit.c
@@ -13,7 +13,7 @@
 #include "net/nanocoap_sock.h"
 #include "firmware/manifest.h"
 
-#define COAP_INBUF_SIZE     (256U)
+#define COAP_INBUF_SIZE     (512U)
 #define STACKSIZE           (2 * THREAD_STACKSIZE_DEFAULT)
 #define PRIO                (THREAD_PRIORITY_MAIN)
 #define TNAME               "coap"


### PR DESCRIPTION
The node was rejecting manifests larger than 256 bytes, which can happen
quite easily. E.g. with the firmware endpoint and a double digit version
number included I've seen manifests being rejected for this reason.

