### PR TITLE
makefiles/riotboot.mk: enforce rule precedence (first signed.bin over .bin) for gnu make

### DIFF
--- a/makefiles/riotboot.mk
+++ b/makefiles/riotboot.mk
@@ -34,7 +34,7 @@ $(BINDIR)/$(APPLICATION)-slot1.elf: ROM_OFFSET=$(SLOT1_OFFSET)
 $(BINDIR)/$(APPLICATION)-slot2.elf: ROM_OFFSET=$(SLOT2_OFFSET)
 
 # create signed binary target
-%.signed.bin: %.sig %.bin
+$(BINDIR)/$(APPLICATION)-slot1.signed.bin $(BINDIR)/$(APPLICATION)-slot2.signed.bin: %.signed.bin: %.sig %.bin
 	@echo "creating $@..."
 	cat $^ > $@
 


### PR DESCRIPTION
### Contribution description
Make sure the rule .signed.bin has precedence over .bin. GNU Make rule precedence is a bit tricky and version dependent. With my GNU Make 3.81 indeed the %.signed.bin rule in riotboot.mk is never called as the %.bin in Makefile.include is called and I end up always with non signed .bin that then do not work. 
By explicitly making it a static rule (by prepending the files that will use it) we make sure it is called and the whole image is now correctly built.

### Testing procedure
Build and flash some firmware updates :)

