### PR TITLE
examples/ota: little corrections and clarifications in the usage readme

### DIFF
--- a/examples/ota/README.md
+++ b/examples/ota/README.md
@@ -18,6 +18,6 @@ CoAP.
 
     $ BOARD=samr21-xpro APP_VER=$(date +%s) make -j4 clean riotboot
 
-- send upate via coap, e.g.,
+- send update via coap, e.g. using libcoap example client,
 
-    $ coap-cli -m put coap://[<node-ip-address]/firmware -b 64 -f bin/samr21-xpro/ota_example-slot2.bin
+    $ coap-client -m put coap://[<node-ip-address>]/firmware -b 64 -f bin/samr21-xpro/ota_example-slot2.signed.bin


### PR DESCRIPTION
### Contribution description
Minor fixes to the readme file for the ota example to make life easier for newcomers. Small typos fixed, referenced the coap client that can be used to test and fix to the command line to use (especially to point at the signed file, otherwise upgrade will not work)
