### PR TITLE
tests/riotboot: add basic automatic test in python

### DIFF
--- a/tests/riotboot/Makefile
+++ b/tests/riotboot/Makefile
@@ -6,6 +6,7 @@ FEATURES_REQUIRED += riotboot
 
 # Include modules to test the bootloader
 USEMODULE += slot_util
+USEMODULE += shell
 
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the

--- a/tests/riotboot/README.md
+++ b/tests/riotboot/README.md
@@ -16,3 +16,6 @@ This test should foremost give you an overview how to use riotboot:
 
 In this test two modules `riot_hdr` and `slot_util` are used to showcase
 the access to riotboot shared functions.
+
+  - `make test` can be executed to run the automatic Python test that checks
+  basic functionalities of riotboot

--- a/tests/riotboot/main.c
+++ b/tests/riotboot/main.c
@@ -21,6 +21,32 @@
 #include <stdio.h>
 
 #include "slot_util.h"
+#include "shell.h"
+
+static int cmd_print_slot_nr(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    printf("Current slot=%d\n", slot_util_current_slot());
+    return 0;
+}
+
+static int cmd_print_slot_hdr(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    int current_slot = slot_util_current_slot();
+    slot_util_print_slot_hdr(current_slot);
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "curslotnr", "Print current slot number", cmd_print_slot_nr },
+    { "curslothdr", "Print current slot header", cmd_print_slot_hdr },
+    { NULL, NULL, NULL }
+};
 
 int main(void)
 {
@@ -41,5 +67,8 @@ int main(void)
         printf("[FAILED] You're not running riotboot\n");
     }
 
+    /* run the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
     return 0;
 }

--- a/tests/riotboot/tests/01-run.py
+++ b/tests/riotboot/tests/01-run.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2018 Federico Pellegrin <fede@evolware.org>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    # Ask for current slot, should be 0 (riotboot slot)
+    child.sendline("curslotnr")
+    child.expect_exact("Current slot=0")
+    child.expect('>')
+
+    # Ask for current slot header info and checks for basic output integrity
+    child.sendline("curslothdr")
+    # Magic number is "RIOT", check for little and big endian
+    child.expect_exact([ "Image magic_number: 0x52494f54", "Image magic_number: 0x544f4952"])
+    # Other info is hardware/app dependant so we just check basic compliance
+    child.expect("Image Version: (0x){0,1}[0-9a-fA-F]+")
+    child.expect("Image start address: 0x[0-9a-fA-F]{8}")
+    child.expect("Image chksum: 0x[0-9a-fA-F]{8}")
+    child.expect('>')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description
This PR adds a basic Python automated test for riotboot, using the standard RIOT test infrastructure.
The automatic test currently checks that the riotboot loader is running, checks that it runs from slot 0 and checks the basic structure and printing of the slot header.
This test aids at speeding up development and eventually in the future enabling this in the CI for regression testing.

### Testing procedure
Go to tests/riotboot. To build and flash you can do as before:

`make all riotboot/flash`

And to run the new automated test:

`make test`

Of course they can all be run in a single step:

`make all riotboot/flash test`

### Issues/PRs references
See also RIOT-OS/RIOT#10065 