### PR TITLE
tests/riotboot: align the check on version format as by latest changes

### DIFF
--- a/tests/riotboot/tests/01-run.py
+++ b/tests/riotboot/tests/01-run.py
@@ -21,7 +21,7 @@ def testfunc(child):
     # Magic number is "RIOT", check for little and big endian
     child.expect_exact(["Image magic_number: 0x52494f54", "Image magic_number: 0x544f4952"])
     # Other info is hardware/app dependant so we just check basic compliance
-    child.expect("Image Version: (0x){0,1}[0-9a-fA-F]+")
+    child.expect("Image Version: 0x[0-9a-fA-F]{8}")
     child.expect("Image start address: 0x[0-9a-fA-F]{8}")
     child.expect("Image chksum: 0x[0-9a-fA-F]{8}")
     child.expect('>')


### PR DESCRIPTION


### Contribution description
This minor PR aligns the test on version value after the last modifications you did that all display as 0x%08x. Previous one would still work but would match also the old (wrong) format or other wrong formats as well.

### Testing procedure
Rerun the automatic test in tests/riotboot and see that it passes correctly for APP_VER=0 and APP_VER!=0.


### Issues/PRs references
See also RIOT-OS/RIOT#10065
