### PR TITLE
tests/riotboot: RIOT string is now always little endian, fix test accordingly

### DIFF
--- a/tests/riotboot/tests/01-run.py
+++ b/tests/riotboot/tests/01-run.py
@@ -18,8 +18,8 @@ def testfunc(child):
 
     # Ask for current slot header info and checks for basic output integrity
     child.sendline("curslothdr")
-    # Magic number is "RIOT", check for little and big endian
-    child.expect_exact(["Image magic_number: 0x52494f54", "Image magic_number: 0x544f4952"])
+    # Magic number is "RIOT" (always in little endian)
+    child.expect_exact("Image magic_number: 0x544f4952")
     # Other info is hardware/app dependant so we just check basic compliance
     child.expect("Image Version: 0x[0-9a-fA-F]{8}")
     child.expect("Image start address: 0x[0-9a-fA-F]{8}")


### PR DESCRIPTION
### Contribution description
RIOT string in riotboot header is now always little endian, so the test must check the result just against little endian and not anymore big endian

### Testing procedure
Build and run automatic test

### Issues/PRs references
As discussed in RIOT-OS/RIOT#10065