### PR TITLE
riotboot: account for flasher building dependencies before trying to use it

### DIFF
--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -96,7 +96,7 @@ $(RIOTBOOT_COMBINED_BIN): $(BOOTLOADER_BIN)/riotboot.extended.bin $(SLOT0_RIOT_B
 riotboot/flash-combined-slot0: HEXFILE=$(RIOTBOOT_COMBINED_BIN)
 # Flashing rule for openocd to flash combined binaries
 riotboot/flash-combined-slot0: export IMAGE_FILE=$(RIOTBOOT_COMBINED_BIN)
-riotboot/flash-combined-slot0: $(RIOTBOOT_COMBINED_BIN)
+riotboot/flash-combined-slot0: $(RIOTBOOT_COMBINED_BIN) $(FLASHDEPS)
 	$(FLASHER) $(FFLAGS)
 
 # Flashing rule for slot 0
@@ -105,7 +105,7 @@ riotboot/flash-slot0: export IMAGE_OFFSET=$(SLOT0_OFFSET)
 riotboot/flash-slot0: HEXFILE=$(SLOT0_RIOT_BIN)
 # openocd
 riotboot/flash-slot0: export IMAGE_FILE=$(SLOT0_RIOT_BIN)
-riotboot/flash-slot0: $(SLOT0_RIOT_BIN)
+riotboot/flash-slot0: $(SLOT0_RIOT_BIN) $(FLASHDEPS)
 	$(FLASHER) $(FFLAGS)
 
 # Targets to generate only slot 0 binary


### PR DESCRIPTION
### Contribution description
Add dependencies from flasher tool before trying to use. Otherwise on a vanilla clean setup currently the flashing will fail since the flasher (ie. edbg) will not be found. This PR follows how this is normally done for normal flashing (see top level Makefile.include)

### Testing procedure
Build and flash tests/riotboot.

### Issues/PRs references
See ongoing work at RIOT-OS/RIOT#10065

